### PR TITLE
Travis and gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ rvm:
   - 2.0.0-p647
   - 2.1.7
   - 2.2.3
+services:
+  - mongodb
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.0.0-p647
+  - 2.1.7
+  - 2.2.3
+script:
+  - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+PATH
+  remote: .
+  specs:
+    dragonfly-mongo_data_store (1.0.0)
+      dragonfly (~> 1.0)
+      mongo (~> 2.0.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    bson (3.2.6)
+    diff-lcs (1.2.5)
+    dragonfly (1.0.12)
+      addressable (~> 2.3)
+      multi_json (~> 1.0)
+      rack (>= 1.3.0)
+    mongo (2.0.6)
+      bson (~> 3.0)
+    multi_json (1.11.2)
+    rack (1.6.4)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dragonfly-mongo_data_store!
+  rspec (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     dragonfly-mongo_data_store (1.0.0)
       dragonfly (~> 1.0)
-      mongo (~> 2.0.6)
+      mongo (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +15,7 @@ GEM
       addressable (~> 2.3)
       multi_json (~> 1.0)
       rack (>= 1.3.0)
-    mongo (2.0.6)
+    mongo (2.1.2)
       bson (~> 3.0)
     multi_json (1.11.2)
     rack (1.6.4)

--- a/dragonfly-mongo_data_store.gemspec
+++ b/dragonfly-mongo_data_store.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dragonfly", "~> 1.0"
-  spec.add_runtime_dependency "mongo", "~> 2.0"
+  spec.add_runtime_dependency "mongo", "~> 2.0.6"
   spec.add_development_dependency "rspec", "~> 2.0"
 end
-

--- a/dragonfly-mongo_data_store.gemspec
+++ b/dragonfly-mongo_data_store.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dragonfly", "~> 1.0"
-  spec.add_runtime_dependency "mongo", "~> 2.0.6"
+  spec.add_runtime_dependency "mongo", "~> 2.1"
   spec.add_development_dependency "rspec", "~> 2.0"
 end

--- a/spec/mongo_data_store_spec.rb
+++ b/spec/mongo_data_store_spec.rb
@@ -59,6 +59,26 @@ describe Dragonfly::MongoDataStore do
     end
   end
 
+
+  describe "write and reads" do
+    it "works for content" do
+      content = Dragonfly::Content.new(app, "gollum")
+      uid = @data_store.write(content)
+      stuff, meta = @data_store.read(uid)
+      retrieved_content = Dragonfly::Content.new(app, stuff, meta)
+      retrieved_content.data.should == "gollum"
+    end
+
+    it "works for empty file" do
+      content = Dragonfly::Content.new(app, "")
+      uid = @data_store.write(content)
+      stuff, meta = @data_store.read(uid)
+      retrieved_content = Dragonfly::Content.new(app, stuff, meta)
+      retrieved_content.data.should == ""
+    end
+  end
+
+
   describe "already stored stuff" do
     it "still works" do
       grid_file = Mongo::Grid::File.new("DOOBS", filename: 'pre-existing', metadata: {'some' => 'meta'})
@@ -77,4 +97,3 @@ describe Dragonfly::MongoDataStore do
   end
 
 end
-

--- a/spec/mongo_data_store_spec.rb
+++ b/spec/mongo_data_store_spec.rb
@@ -53,7 +53,7 @@ describe Dragonfly::MongoDataStore do
     it "should be available in the metadata (taken from ext)" do
       content.name = 'text.txt'
       uid = @data_store.write(content)
-      data, meta = @data_store.read(BSON::ObjectId(uid));
+      data, meta = @data_store.read(BSON::ObjectId.from_string(uid));
       meta[:content_type].should == 'text/plain'
       data.should == content.data
     end


### PR DESCRIPTION
Mark this branch as only compatible with mongo 2.1+

Port of the metadata changes in #1.

The actual fix from #1 is not required here.
